### PR TITLE
Add autohooks-reviewer team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default reviewers
-*                 @greenbone/devops
+*                 @greenbone/devops @greenbone/autohooks-reviewer


### PR DESCRIPTION
## What and Why

Add `autohooks-reviewer` team to `CODEOWNERS` to enable additional reviewers.

## References

DEVOPS-2081